### PR TITLE
Enable ECMAScript 6, convert models and collections to ES6 modules

### DIFF
--- a/js/collections/todos.js
+++ b/js/collections/todos.js
@@ -1,38 +1,37 @@
-/*global define */
-define([
-	'underscore',
-	'backbone',
-	'backboneLocalstorage',
-	'models/todo'
-], function (_, Backbone, Store, Todo) {
-	'use strict';
+import _ from 'underscore';
+import { Collection } from 'backbone';
+import Store from 'backbone.localstorage';
+import Todo from 'models/todo';
 
-	var TodosCollection = Backbone.Collection.extend({
-		// Reference to this collection's model.
-		model: Todo,
+class TodosCollection extends Collection {
+  constructor(models, options) {
+    // Reference to this collection's model.
+    this.model = Todo;
 
-		// Save all of the todo items under the `"todos"` namespace.
-		localStorage: new Store('todos-backbone'),
+    // Save all of the todo items under the `"todos"` namespace.
+    this.localStorage = new Store('todos-backbone');
 
-		// Filter down the list of all todo items that are finished.
-		completed: function () {
-			return this.where({completed: true});
-		},
+    // Todos are sorted by their original insertion order.
+    this.comparator = 'order';
 
-		// Filter down the list to only todo items that are still not finished.
-		remaining: function () {
-			return this.where({completed: false});
-		},
+    super(models, options);
+  }
 
-		// We keep the Todos in sequential order, despite being saved by unordered
-		// GUID in the database. This generates the next order number for new items.
-		nextOrder: function () {
-			return this.length ? this.last().get('order') + 1 : 1;
-		},
+  // Filter down the list of all todo items that are finished.
+  completed() {
+    return this.where({completed: true});
+  }
 
-		// Todos are sorted by their original insertion order.
-		comparator: 'order'
-	});
+  // Filter down the list to only todo items that are still not finished.
+  remaining() {
+    return this.where({completed: false});
+  }
 
-	return new TodosCollection();
-});
+  // We keep the Todos in sequential order, despite being saved by unordered
+  // GUID in the database. This generates the next order number for new items.
+  nextOrder() {
+    return this.length ? this.last().get('order') + 1 : 1;
+  }
+}
+
+export default new TodosCollection();

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,7 @@
 'use strict';
 
+require('es5-shim');
+
 require('todomvc-common');
 require('todomvc-common/base.css');
 require('todomvc-app-css/index.css');

--- a/js/models/todo.js
+++ b/js/models/todo.js
@@ -1,25 +1,21 @@
-/*global define*/
-define([
-	'underscore',
-	'backbone'
-], function (_, Backbone) {
-	'use strict';
+import { Model } from 'backbone';
 
-	var Todo = Backbone.Model.extend({
-		// Default attributes for the todo
-		// and ensure that each todo created has `title` and `completed` keys.
-		defaults: {
-			title: '',
-			completed: false
-		},
+class Todo extends Model {
+  // Default attributes for the todo
+  // and ensure that each todo created has `title` and `completed` keys.
+  defaults() {
+    return {
+      title: '',
+      completed: false
+    };
+  }
 
-		// Toggle the `completed` state of this todo item.
-		toggle: function () {
-			this.save({
-				completed: !this.get('completed')
-			});
-		}
-	});
+  // Toggle the `completed` state of this todo item.
+  toggle() {
+    this.save({
+      completed: !this.get('completed')
+    });
+  }
+}
 
-	return Todo;
-});
+export default Todo;

--- a/package.json
+++ b/package.json
@@ -3,12 +3,15 @@
   "dependencies": {
     "backbone": "^1.1.2",
     "backbone.localstorage": "^1.1.16",
+    "es5-shim": "^4.1.0",
     "jquery": "^2.1.3",
     "todomvc-app-css": "^1.0.0",
     "todomvc-common": "^1.0.1",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
+    "babel-core": "^4.7.13",
+    "babel-loader": "^4.2.0",
     "css-loader": "^0.9.1",
     "style-loader": "^0.8.3",
     "text-loader": "0.0.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,9 +23,7 @@ module.exports = {
     modulesDirectories: ['js', 'node_modules'],
 
     // Replace modules with other modules or paths for compatibility or convenience
-    alias: {
-      'backboneLocalstorage': 'backbone.localstorage'
-    }
+    alias: {}
   },
 
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ module.exports = {
 
   module: {
     loaders: [
+      {test: /\.js$/, loaders: ['babel?experimental'], exclude: /node_modules/},
       {test: /\.css$/, loaders: ['style', 'css']}
     ]
   }


### PR DESCRIPTION
When `babel-loader` is added to the webpack config, it enables ES6 to be used throughout the app.

[http://babeljs.io/](http://babeljs.io/) transpiles ES6 to code supported by ES5 browsers, enabling the use of the latest and greatest JavaScript APIs and syntaxes in your codebase. You can use `es5-shim` to ensure that this code runs on older browsers.
